### PR TITLE
Add support for configuring paths via loaderOptions

### DIFF
--- a/less.js
+++ b/less.js
@@ -14,10 +14,16 @@ module.exports = new CSSPluginBase(function compile(style, address, opts) {
 
   return System['import']('lesscss', module.id)
   .then(function(less) {
+    var paths = opts.paths || [];
+
+    if (opts.fileAsRoot) {
+      paths.push(filename.replace(/[^/]+$/, ''));
+    }
+
     return less.render(style, {
       filename: filename,
       rootpath: (!opts.fileAsRoot || !loader.builder) && filename.replace(/[^/]+$/, ''),
-      paths: opts.fileAsRoot && [filename.replace(/[^/]+$/, '')],
+      paths: paths,
       relativeUrls: opts.relativeUrls || false,
       sourceMap: loader.builder && {
         sourceMapBasepath: filename.replace(/[^/]+$/, '')
@@ -29,7 +35,7 @@ module.exports = new CSSPluginBase(function compile(style, address, opts) {
       css: output.css + (loader.builder ? '' : ('/*# sourceURL=' + filename + '*/')),
       map: output.map,
 
-      // style plugins can optionally return a modular module 
+      // style plugins can optionally return a modular module
       // source as well as the stylesheet above
       moduleSource: null,
       moduleFormat: null


### PR DESCRIPTION
Currently we use LESS in a way that all `@import` statements paths should be treated as if the URL traverses from the root directory of our CSS codebase. We use `paths` configuration for this to make it happen and prevent traversing back to the parent directories. In order to move this across and use `plugin-less` I exported `paths` to `loaderOptions` for extra configuration.

Just wondering if this is suitable upstream. Thanks in advance!
